### PR TITLE
chore: class cannot be final when lazy loaded

### DIFF
--- a/src/Development/Process/BoxProcessProvider.php
+++ b/src/Development/Process/BoxProcessProvider.php
@@ -5,7 +5,7 @@ namespace EFrane\PharBuilder\Development\Process;
 /**
  * Build a command for Box with the correct location.
  */
-final class BoxProcessProvider extends AbstractProcessProvider implements ProcessProviderInterface
+class BoxProcessProvider extends AbstractProcessProvider implements ProcessProviderInterface
 {
     public function getName(): string
     {


### PR DESCRIPTION
Current master branch throws an error during upgrade to symfony 6.4

Script cache:clear returned with error code 1
!!  
!!  In LazyServiceDumper.php line 138:
!!                                                                                 
!!    Cannot generate lazy proxy for service "EFrane\PharBuilder\Development\Proc  
!!    ess\BoxProcessProvider".                                                     
!!                                                                                 
!!  
!!  In ProxyHelper.php line 92:
!!                                                                                 
!!    Cannot generate lazy proxy: class "EFrane\PharBuilder\Development\Process\B  
!!    oxProcessProvider" is final.                                                 
!!                                                                                 
!! 

Is there a need for BoxProcessProvider to be final?